### PR TITLE
Fixing content build errors

### DIFF
--- a/chain/d8sandbox.yml
+++ b/chain/d8sandbox.yml
@@ -24,7 +24,8 @@ commands:
       title-words: 5
       time-range: N
     arguments:
-      content-types: Article
+      content-types: 
+        - article
 # Generate Basic Page content
   - command: create:nodes
     options:
@@ -32,7 +33,8 @@ commands:
       title-words: 5
       time-range: N
     arguments:
-      content-types: 'Basic Page'
+      content-types:
+        - page
 # Provide user login URL
   - command: user:login:url
     arguments:


### PR DESCRIPTION
I was getting errors when building out the content for this, looks like `content-types` wants an array and not a string.
